### PR TITLE
rename display symbol for statUSDC

### DIFF
--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Deposit.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Deposit.e2e.js
@@ -45,7 +45,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]')
       .should('exist')
-      .and('include.text', '462.82 Static aUSDC');
+      .and('include.text', '462.82 USDC via Aave');
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]').should('not.exist');
 
@@ -54,7 +54,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]')
       .should('exist')
-      .and('include.text', '647.95 Static aUSDC'); // Adjusted per stata rate
+      .and('include.text', '647.95 USDC via Aave'); // Adjusted per stata rate
 
     cy.get('[data-cy="deposit submit"]').should('be.enabled');
     cy.get('[data-cy="deposit submit"]').click();
@@ -79,7 +79,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]', {
       timeout: 60_000,
-    }).and('include.text', '647.95 Static aUSDC');
+    }).and('include.text', '647.95 USDC via Aave');
     cy.get('[data-cy="deposit submit"]').should('be.disabled');
   });
 });

--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_InitialDeposit.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_InitialDeposit.e2e.js
@@ -44,7 +44,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]')
       .should('exist')
-      .and('include.text', '0 Static aUSDC');
+      .and('include.text', '0 USDC Via Aave');
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]').should('not.exist');
 
     cy.get('[data-cy="deposit amount input"]').should('exist');
@@ -52,7 +52,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]')
       .should('exist')
-      .and('include.text', '462.82 Static aUSDC');
+      .and('include.text', '462.82 USDC Via Aave');
 
     cy.get('[data-cy="deposit submit"]').should('be.enabled');
     cy.get('[data-cy="deposit submit"]').click();
@@ -77,7 +77,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]', {
       timeout: 60_000,
-    }).and('include.text', '462.82 Static aUSDC');
+    }).and('include.text', '462.82 USDC Via Aave');
     cy.get('[data-cy="deposit submit"]').should('be.disabled');
   });
 });

--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_InitialDeposit.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_InitialDeposit.e2e.js
@@ -44,7 +44,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]')
       .should('exist')
-      .and('include.text', '0 USDC Via Aave');
+      .and('include.text', '0 USDC via Aave');
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]').should('not.exist');
 
     cy.get('[data-cy="deposit amount input"]').should('exist');
@@ -52,7 +52,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]')
       .should('exist')
-      .and('include.text', '462.82 USDC Via Aave');
+      .and('include.text', '462.82 USDC via Aave');
 
     cy.get('[data-cy="deposit submit"]').should('be.enabled');
     cy.get('[data-cy="deposit submit"]').click();
@@ -77,7 +77,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]', {
       timeout: 60_000,
-    }).and('include.text', '462.82 USDC Via Aave');
+    }).and('include.text', '462.82 USDC via Aave');
     cy.get('[data-cy="deposit submit"]').should('be.disabled');
   });
 });

--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Unlock.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Unlock.e2e.js
@@ -53,7 +53,7 @@ describe(__filename, () => {
     cy.get('[data-cy="undelegate dialog"]')
       .should('exist')
       .and('include.text', 'Unlocking Collateral')
-      .and('include.text', 'Unlocking 100 Static aUSDC');
+      .and('include.text', 'Unlocking 100 USDC via Aave');
 
     cy.contains('[data-status="success"]', 'Your collateral has been updated', {
       timeout: 180_000,
@@ -62,7 +62,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="undelegate dialog"]')
       .should('exist')
-      .and('include.text', 'Unlocked 100 Static aUSDC');
+      .and('include.text', 'Unlocked 100 USDC via Aave');
 
     cy.contains('[data-cy="undelegate dialog"] button', 'Done').click();
 

--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Withdraw.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Withdraw.e2e.js
@@ -49,7 +49,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]')
       .should('exist')
-      .and('include.text', '370.25 USDC Via Aave');
+      .and('include.text', '370.25 USDC via Aave');
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]').should('not.exist');
 
@@ -82,7 +82,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]').and(
       'include.text',
-      '370.25 USDC Via Aave'
+      '370.25 USDC via Aave'
     );
     cy.get('[data-cy="withdraw submit"]').should('be.disabled');
   });

--- a/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Withdraw.e2e.js
+++ b/liquidity/cypress/cypress/e2e/8453-andromeda/stataUSDC_Withdraw.e2e.js
@@ -49,7 +49,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]')
       .should('exist')
-      .and('include.text', '370.25 Static aUSDC');
+      .and('include.text', '370.25 USDC Via Aave');
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats new"]').should('not.exist');
 
@@ -82,7 +82,7 @@ describe(__filename, () => {
 
     cy.get('[data-cy="stats collateral"] [data-cy="change stats current"]').and(
       'include.text',
-      '370.25 Static aUSDC'
+      '370.25 USDC Via Aave'
     );
     cy.get('[data-cy="withdraw submit"]').should('be.disabled');
   });

--- a/liquidity/lib/Deposit/Deposit.tsx
+++ b/liquidity/lib/Deposit/Deposit.tsx
@@ -218,7 +218,7 @@ export function Deposit() {
         <Alert mb={6} status="info" borderRadius="6px">
           <AlertIcon />
           <AlertDescription>
-            Deposit USDC and it will automatically wrap into Static aUSDC
+            Deposit USDC and it will automatically wrap into USDC via Aave
           </AlertDescription>
         </Alert>
       </Collapse>

--- a/liquidity/lib/Manage/StataDepositBanner.tsx
+++ b/liquidity/lib/Manage/StataDepositBanner.tsx
@@ -17,7 +17,7 @@ export function StataDepositBanner() {
           This position earns yield via Aave and Synthetix
         </Text>
         <Text color="white.600" fontSize="14px" fontWeight={300}>
-          Deposit USDC, and we’ll wrap it into Static aUSDC for you. Watch your balance stay the
+          Deposit USDC, and we’ll wrap it into USDC via Aave for you. Watch your balance stay the
           same while the value grows, earning effortless yield through Aave and Synthetix.
         </Text>
         <Button
@@ -30,7 +30,7 @@ export function StataDepositBanner() {
           colorScheme="gray"
           w="fit-content"
         >
-          Read more about Static aUSDC
+          Read more about USDC via Aave
         </Button>
       </Flex>
 

--- a/liquidity/lib/Synths/StataUSDC.tsx
+++ b/liquidity/lib/Synths/StataUSDC.tsx
@@ -83,7 +83,7 @@ export function StataUSDC() {
       toast.closeAll();
       toast({
         title: 'Success',
-        description: 'Your Static aUSDC has been unwrapped to USDC.',
+        description: 'Your USDC via Aave has been unwrapped to USDC.',
         status: 'success',
         duration: 5000,
         variant: 'left-accent',
@@ -138,7 +138,7 @@ export function StataUSDC() {
             fontFamily="heading"
             fontSize="sm"
           >
-            Static aUSDC
+            USDC via Aave
           </Text>
         </Flex>
       </Flex>

--- a/liquidity/lib/constants/constants.ts
+++ b/liquidity/lib/constants/constants.ts
@@ -91,7 +91,7 @@ export const tokenOverrides: {
   '8453-andromeda': {
     '0x4EA71A20e655794051D1eE8b6e4A3269B13ccaCc': {
       symbol: 'stataUSDC',
-      displaySymbol: 'Static aUSDC',
+      displaySymbol: 'USDC via Aave',
       name: 'Static aUSDC',
     },
   },

--- a/liquidity/lib/constants/constants.ts
+++ b/liquidity/lib/constants/constants.ts
@@ -92,7 +92,7 @@ export const tokenOverrides: {
     '0x4EA71A20e655794051D1eE8b6e4A3269B13ccaCc': {
       symbol: 'stataUSDC',
       displaySymbol: 'USDC via Aave',
-      name: 'Static aUSDC',
+      name: 'USDC via Aave',
     },
   },
   '1-main': {

--- a/liquidity/lib/useCollateralTypes/useCollateralTypes.ts
+++ b/liquidity/lib/useCollateralTypes/useCollateralTypes.ts
@@ -85,8 +85,8 @@ export function useCollateralTypes(includeDelegationOff = false, customNetwork?:
             return {
               ...collateralType,
               symbol: 'stataUSDC',
-              displaySymbol: 'USDC Via Aave',
-              name: 'Static aUSDC',
+              displaySymbol: 'USDC via Aave',
+              name: 'USDC via Aave',
             };
           }
 

--- a/liquidity/lib/useCollateralTypes/useCollateralTypes.ts
+++ b/liquidity/lib/useCollateralTypes/useCollateralTypes.ts
@@ -85,7 +85,7 @@ export function useCollateralTypes(includeDelegationOff = false, customNetwork?:
             return {
               ...collateralType,
               symbol: 'stataUSDC',
-              displaySymbol: 'Static aUSDC',
+              displaySymbol: 'USDC Via Aave',
               name: 'Static aUSDC',
             };
           }


### PR DESCRIPTION
**Changes**:
rename "stataUSDC" to "USDC via Aave"

**Ticket**: 
https://linear.app/ccsnx/issue/SNX-1722/rename-statausdc-vault-to-usdc-via-aave